### PR TITLE
Support for eJabberd 17.03+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ebin
 rel/example_project
 .concrete/DEV_MODE
 .rebar
+.idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Ejabberd 16.08 module to send offline user's message via POST request to target URL.
+Ejabberd 16.* and 17.* module to send offline user's message via POST request to target URL.
 The main motivation for this module is to use it with push notifications. The request body is in JSON format. See the example below.
+
+Tested with eJabberd 17.04.
 
 
 Installation
@@ -18,6 +20,7 @@ Add the following to ejabberd configuration under `modules:`
 ```
 mod_offline_http_post:
     auth_token: "secret"
+    auth_token_key: "access_token"
     post_url: "http://example.com/notify"
 ```
 

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -1,45 +1,41 @@
 %% name of module must match file name
+%% Contribution: realbudhead@gmail.com
 -module(mod_offline_http_post).
 -author("dev@codepond.org").
 
 -behaviour(gen_mod).
 
--export([start/2, stop/1, create_message/3]).
+-export([start/2, stop/1, create_message/1]).
 
 -include("ejabberd.hrl").
--include("jlib.hrl").
+-include("xmpp.hrl").
 -include("logger.hrl").
 
 start(_Host, _Opt) ->
-	?INFO_MSG("mod_offline_http_post loading", []),
-	inets:start(),
-	?INFO_MSG("HTTP client started", []),
-	ejabberd_hooks:add(offline_message_hook, _Host, ?MODULE, create_message, 1).
+        ?INFO_MSG("mod_offline_http_post loading", []),
+        inets:start(),
+        ?INFO_MSG("HTTP client started", []),
+        ejabberd_hooks:add(offline_message_hook, _Host, ?MODULE, create_message, 1).
 
 stop (_Host) ->
-	?INFO_MSG("stopping mod_offline_http_post", []),
-	ejabberd_hooks:delete(offline_message_hook, _Host, ?MODULE, create_message, 1).
+        ?INFO_MSG("stopping mod_offline_http_post", []),
+        ejabberd_hooks:delete(offline_message_hook, _Host, ?MODULE, create_message, 1).
 
-create_message(_From, _To, Packet) ->
-	Type = fxml:get_tag_attr_s(list_to_binary("type"), Packet),
-	Body = fxml:get_path_s(Packet, [{elem, list_to_binary("body")}, cdata]),
-	MessageId = fxml:get_tag_attr_s(list_to_binary("id"), Packet),
-
-	if (Type == <<"chat">>) and (Body /= <<"">>) ->
-		post_offline_message(_From, _To, Body, "SubType", MessageId)
-	end.
+create_message({Action, Packet} = Acc)
+        when (Packet#message.type == chat) and (Packet#message.body /= []) ->
+        ?INFO_MSG("Posting: ~p To ~p",[Packet#message.from, Packet#message.to]),
+        [{text, _, Body}] = Packet#message.body,
+        post_offline_message(Packet#message.to, Packet#message.from, Body, "SubType", Packet#message.id),
+        Acc.
 
 post_offline_message(From, To, Body, SubType, MessageId) ->
-	?INFO_MSG("Posting From ~p To ~p Body ~p SubType ~p ID ~p~n",[From, To, Body, SubType, MessageId]),
-	Sep = "',",
-    Token = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, auth_token, fun(S) -> iolist_to_binary(S) end, list_to_binary("")),
-    PostUrl = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, post_url, fun(S) -> iolist_to_binary(S) end, list_to_binary("")),
-	Post = [
-		"{'to':'", To#jid.luser, Sep,
-        "'from':'", From#jid.luser, Sep,
-		"'body':'", binary_to_list(Body), Sep,
-		"'message_id':'", binary_to_list(MessageId), Sep,
-		"'access_token':'", Token, "'}"
-	],
-	httpc:request(post, {binary_to_list(PostUrl), [], "application/json", list_to_binary(Post)},[],[]),
-	?INFO_MSG("post request sent", []).
+        ?INFO_MSG("Posting From ~p To ~p Body ~p",[From, To, Body]),
+        Token = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, auth_token, fun(S) -> iolist_to_binary(S) end, list_to_binary("")),
+        PostUrl = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, post_url, fun(S) -> iolist_to_binary(S) end, list_to_binary("")),
+        ToUser = To#jid.luser,
+        FromUser = From#jid.luser,
+        Vhost = To#jid.lserver,
+        Data = string:join(["access_token=", binary_to_list(Token), "&to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)$
+        Request = {binary_to_list(PostUrl), [{"Authorization", binary_to_list(Token)}], "application/x-www-form-urlencoded", Data},
+        httpc:request(post, Request,[],[]),
+        ?INFO_MSG("post request sent", []).

--- a/src/mod_offline_http_post.erl
+++ b/src/mod_offline_http_post.erl
@@ -1,11 +1,11 @@
 %% name of module must match file name
-%% Contribution: realbudhead@gmail.com
+%% Contribution: @realbudhead
 -module(mod_offline_http_post).
 -author("dev@codepond.org").
 
 -behaviour(gen_mod).
 
--export([start/2, stop/1, create_message/1]).
+-export([start/2, stop/1, create_message/1, create_message/3]).
 
 -include("ejabberd.hrl").
 -include("xmpp.hrl").
@@ -21,21 +21,26 @@ stop (_Host) ->
         ?INFO_MSG("stopping mod_offline_http_post", []),
         ejabberd_hooks:delete(offline_message_hook, _Host, ?MODULE, create_message, 1).
 
-create_message({Action, Packet} = Acc)
-        when (Packet#message.type == chat) and (Packet#message.body /= []) ->
-        ?INFO_MSG("Posting: ~p To ~p",[Packet#message.from, Packet#message.to]),
+create_message({Action, Packet} = Acc) when (Packet#message.type == chat) and (Packet#message.body /= []) ->
         [{text, _, Body}] = Packet#message.body,
-        post_offline_message(Packet#message.to, Packet#message.from, Body, "SubType", Packet#message.id),
+        post_offline_message(Packet#message.from, Packet#message.to, Body, "SubType", Packet#message.id),
         Acc.
 
+create_message(_From, _To, Packet) when (Packet#message.type == chat) and (Packet#message.body /= []) ->
+        Body = fxml:get_path_s(Packet, [{elem, list_to_binary("body")}, cdata]),
+        MessageId = fxml:get_tag_attr_s(list_to_binary("id"), Packet),
+        post_offline_message(_From, _To, Body, "SubType", MessageId),
+        ok.
+
 post_offline_message(From, To, Body, SubType, MessageId) ->
-        ?INFO_MSG("Posting From ~p To ~p Body ~p",[From, To, Body]),
         Token = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, auth_token, fun(S) -> iolist_to_binary(S) end, list_to_binary("")),
         PostUrl = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, post_url, fun(S) -> iolist_to_binary(S) end, list_to_binary("")),
+        AuthTokenKey = gen_mod:get_module_opt(To#jid.lserver, ?MODULE, auth_token_key, fun(S) -> iolist_to_binary(S) end, list_to_binary("access_token")),
         ToUser = To#jid.luser,
         FromUser = From#jid.luser,
         Vhost = To#jid.lserver,
-        Data = string:join(["access_token=", binary_to_list(Token), "&to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_list(MessageId)$
+        ?INFO_MSG("Posting From ~p To ~p Body ~p",[FromUser, ToUser, Body]),
+        Data = string:join([binary_to_list(AuthTokenKey), binary_to_list(Token), "&to=", binary_to_list(ToUser), "&from=", binary_to_list(FromUser), "&vhost=", binary_to_list(Vhost), "&body=", binary_to_list(Body), "&messageId=", binary_to_li$
         Request = {binary_to_list(PostUrl), [{"Authorization", binary_to_list(Token)}], "application/x-www-form-urlencoded", Data},
         httpc:request(post, Request,[],[]),
         ?INFO_MSG("post request sent", []).


### PR DESCRIPTION
I added a new function with one parameter (that's what eJabberd 17.03 expects) that extracts the parameters and sends them to the old function.

I added additional parameters in the config file for authentication key.

Removed jlib.hrl and included the new xmpp.hrl

Additionally I made small refactorings.